### PR TITLE
fix spelling, pallete -> palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ var encodeParams = {
     crc: true,              // Set to false to skip verifying/adding CRC (default is true)
     keepMetaData: true,     // Set to false to strip EXIF/XMP metadata (default is true)
     keepColorProfile: true, // Set to false to strip ICC color profile (default is true)
-    keepPalette: false,     // Set to true to keep the existing PNG pallete. (default is false)
+    keepPalette: false,     // Set to true to keep the existing PNG palette. (default is false)
     frameDelay: [100],      // Animation frame delay in ms. Array of number(s). (default is [100] which applies to all frames)
     // Advanced optional encoding parameters
     maxPaletteSize: 512,    // Max number of colors to store in a FLIF palette. PNG/GIF use 256. (FLIF default is 512)

--- a/src/conversion/encode.js
+++ b/src/conversion/encode.js
@@ -15,7 +15,7 @@ var encodeParams = {
     crc: true,              // Set to false to skip verifying/adding CRC (default is true)
     keepMetaData: true,     // Set to false to strip EXIF/XMP metadata (default is true)
     keepColorProfile: true, // Set to false to strip ICC color profile (default is true)
-    keepPalette: false,     // Set to true to keep the existing PNG pallete. (default is false)
+    keepPalette: false,     // Set to true to keep the existing PNG palette. (default is false)
     frameDelay: 100,        // Pass in a single number or an array of numbers for animations. (default is 100)
     // Advanced optional encoding parameters
     maxPaletteSize: 512,    // Max number of colors to store in a FLIF palette. PNG/GIF use 256. (FLIF default is 512)

--- a/src/conversion/transcode.js
+++ b/src/conversion/transcode.js
@@ -16,7 +16,7 @@ var encodeParams = {
     crc: true,              // Set to false to skip verifying/adding CRC (default is true)
     keepMetaData: true,     // Set to false to strip EXIF/XMP metadata (default is true)
     keepColorProfile: true, // Set to false to strip ICC color profile (default is true)
-    keepPalette: false,     // Set to true to keep the existing PNG pallete. (default is false)
+    keepPalette: false,     // Set to true to keep the existing PNG palette. (default is false)
     frameDelay: 100,        // Pass in a single number or an array of numbers for animations. (default is 100)
     // Advanced optional encoding parameters
     maxPaletteSize: 512,    // Max number of colors to store in a FLIF palette. PNG/GIF use 256. (FLIF default is 512)


### PR DESCRIPTION
fixed in JS comments and README, no code changes 